### PR TITLE
Added interaction log details bottom sheet

### DIFF
--- a/app/src/main/java/org/brightmindenrichment/street_care/ui/visit/VisitFormFragment0.kt
+++ b/app/src/main/java/org/brightmindenrichment/street_care/ui/visit/VisitFormFragment0.kt
@@ -28,11 +28,24 @@ import org.brightmindenrichment.street_care.ui.visit.interaction_logs.Interactio
 import org.brightmindenrichment.street_care.ui.visit.visit_forms.DetailsButtonClickListener
 import org.brightmindenrichment.street_care.ui.visit.visit_forms.VisitLogRecyclerAdapter
 import org.brightmindenrichment.street_care.util.featureflags.FeatureFlag
+import org.brightmindenrichment.street_care.ui.visit.InteractionLogDataAdapter
+import org.brightmindenrichment.street_care.ui.visit.data.InteractionLog
+import org.brightmindenrichment.street_care.ui.visit.visit_forms.InteractionLogRecyclerAdapter
 import org.brightmindenrichment.street_care.util.featureflags.FeatureFlagManager
+import org.brightmindenrichment.street_care.ui.visit.visit_forms.InteractionDetailsButtonClickListener
+
+import androidx.core.content.ContextCompat
+import com.google.android.flexbox.FlexboxLayout
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import java.text.SimpleDateFormat
+import java.util.Locale
+
 
 class VisitFormFragment0 : Fragment() {
     private var _binding: FragmentVisitBinding? = null
     val binding get() = _binding!!
+
+    private val interactionLogDataAdapter = InteractionLogDataAdapter()
     private val viewModel: InteractionLogViewModel by activityViewModels()
     private val visitDataAdapter = VisitDataAdapter()
     private var draftExists = false
@@ -106,31 +119,173 @@ class VisitFormFragment0 : Fragment() {
             .show()
     }
     private fun updateUI() {
-        visitDataAdapter.refreshAll {
-            val recyclerView = view?.findViewById<RecyclerView>(R.id.recyclerView_visit)
-            recyclerView?.layoutManager = LinearLayoutManager(view?.context)
-            recyclerView?.adapter = VisitLogRecyclerAdapter(
-                requireContext(),
-                visitDataAdapter,
-                object : DetailsButtonClickListener {
-                    override fun onClick(visitLog: VisitLog) {
-                        val bundle = bundleOf("visitlogId" to visitLog)
-                        findNavController().navigate(
-                            R.id.action_nav_visit_to_visitLogDetailsFragment, bundle
-                        )
-                    }
-                })
-            val totalItemsDonated = visitDataAdapter.getTotalItemsDonated
-            val totalOutreaches = visitDataAdapter.size
-            val totalPeopleHelped = visitDataAdapter.getTotalPeopleCount
 
+        interactionLogDataAdapter.refreshAll {
+            val recyclerView = view?.findViewById<RecyclerView>(R.id.recyclerView_visit)
+
+            recyclerView?.layoutManager = LinearLayoutManager(view?.context)
+
+            recyclerView?.adapter = InteractionLogRecyclerAdapter(
+                requireContext(),
+                interactionLogDataAdapter,
+                object : InteractionDetailsButtonClickListener {
+                    override fun onClick(interactionLog: InteractionLog) {
+                        showInteractionLogDetailsSheet(interactionLog)
+                    }
+                }
+            )
+
+            val totalItemsDonated =
+                interactionLogDataAdapter.interactions.sumOf { it.carePackagesDistributed }
+
+            val totalOutreaches =
+                interactionLogDataAdapter.size
+
+            val totalPeopleHelped =
+                interactionLogDataAdapter.interactions.sumOf { it.numPeopleHelped }
 
             binding.txtItemDonate.text = totalItemsDonated.toString()
             binding.txtOutreaches.text = totalOutreaches.toString()
             binding.txtPplHelped.text = totalPeopleHelped.toString()
         }
 
+    }
 
+    private fun showInteractionLogDetailsSheet(interactionLog: InteractionLog) {
+        val bottomSheetDialog = BottomSheetDialog(requireContext())
+        val sheetView = layoutInflater.inflate(
+            R.layout.bottom_sheet_interaction_log_details,
+            null
+        )
+
+        sheetView.findViewById<TextView>(R.id.tvInteractionName).text =
+            interactionLog.displayName()
+
+        sheetView.findViewById<TextView>(R.id.tvInteractionDate).text =
+            interactionLog.formattedDate()
+
+        sheetView.findViewById<TextView>(R.id.tvInteractionCityState).text =
+            interactionLog.formattedCityState()
+
+        sheetView.findViewById<TextView>(R.id.tvInteractionPhone).text =
+            interactionLog.phoneNumber.ifBlank { "N/A" }
+
+        sheetView.findViewById<TextView>(R.id.tvInteractionTime).text =
+            interactionLog.formattedTimeRange()
+
+        sheetView.findViewById<TextView>(R.id.tvInteractionAddress).text =
+            interactionLog.formattedAddress()
+
+        sheetView.findViewById<TextView>(R.id.tvInteractionEmail).text =
+            interactionLog.email.ifBlank { "N/A" }
+
+        sheetView.findViewById<TextView>(R.id.tvPeopleJoined).text =
+            getString(R.string.people_joined_count, interactionLog.numPeopleJoined)
+
+        sheetView.findViewById<TextView>(R.id.tvHelpRequestCount).text =
+            getString(R.string.help_request_count_value, interactionLog.helpRequestCount)
+
+        sheetView.findViewById<TextView>(R.id.tvPeopleHelped).text =
+            getString(R.string.people_helped_count, interactionLog.numPeopleHelped)
+
+        sheetView.findViewById<TextView>(R.id.tvCarePackagesDistributed).text =
+            getString(
+                R.string.care_packages_distributed_count,
+                interactionLog.carePackagesDistributed
+            )
+
+        val chipContainer =
+            sheetView.findViewById<FlexboxLayout>(R.id.supportChipContainer)
+
+        chipContainer.removeAllViews()
+
+        val supportItems = interactionLog.listOfSupportsProvided
+            .ifEmpty { interactionLog.carePackageContents }
+
+        supportItems.forEach { support ->
+            chipContainer.addView(createSupportChip(support))
+        }
+
+        sheetView.findViewById<TextView>(R.id.btnCloseInteractionDetails)
+            .setOnClickListener {
+                bottomSheetDialog.dismiss()
+            }
+
+        bottomSheetDialog.setContentView(sheetView)
+
+        bottomSheetDialog.setOnShowListener { dialog ->
+            val bottomSheet = (dialog as BottomSheetDialog)
+                .findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
+
+            bottomSheet?.background = null
+        }
+
+        bottomSheetDialog.show()
+    }
+
+    private fun InteractionLog.displayName(): String {
+        return listOf(firstName, lastName)
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .joinToString(" ")
+            .ifBlank { "N/A" }
+    }
+
+    private fun InteractionLog.formattedDate(): String {
+        val date = startTimestamp?.toDate() ?: return "N/A"
+        return SimpleDateFormat("MM/dd/yyyy", Locale.getDefault()).format(date)
+    }
+
+    private fun InteractionLog.formattedTimeRange(): String {
+        val start = startTimestamp?.toDate()
+        val end = endTimestamp?.toDate()
+
+        if (start == null && end == null) return "N/A"
+
+        val formatter = SimpleDateFormat("hh:mm a", Locale.getDefault())
+
+        return when {
+            start != null && end != null -> "${formatter.format(start)} - ${formatter.format(end)}"
+            start != null -> formatter.format(start)
+            else -> "N/A"
+        }
+    }
+
+    private fun InteractionLog.formattedCityState(): String {
+        return listOf(city, state)
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .joinToString(", ")
+            .ifBlank { "N/A" }
+    }
+
+    private fun InteractionLog.formattedAddress(): String {
+        return listOf(addr1, addr2, city, state, zipcode, country)
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .joinToString(", ")
+            .ifBlank { "N/A" }
+    }
+
+    private fun createSupportChip(text: String): TextView {
+        return TextView(requireContext()).apply {
+            this.text = text
+            setTextColor(ContextCompat.getColor(requireContext(), R.color.gray700))
+            textSize = 13f
+            setPadding(14.dp(), 6.dp(), 14.dp(), 6.dp())
+            background = ContextCompat.getDrawable(requireContext(), R.drawable.bg_interaction_chip)
+
+            layoutParams = FlexboxLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            ).apply {
+                setMargins(0, 0, 8.dp(), 8.dp())
+            }
+        }
+    }
+
+    private fun Int.dp(): Int {
+        return (this * resources.displayMetrics.density).toInt()
     }
     fun showCustomDialog() {
         val dialogView = layoutInflater.inflate(R.layout.dialog_login_2, null)

--- a/app/src/main/java/org/brightmindenrichment/street_care/ui/visit/visit_forms/InteractionDetailsButtonClickListener.kt
+++ b/app/src/main/java/org/brightmindenrichment/street_care/ui/visit/visit_forms/InteractionDetailsButtonClickListener.kt
@@ -1,0 +1,8 @@
+package org.brightmindenrichment.street_care.ui.visit.visit_forms
+
+
+import org.brightmindenrichment.street_care.ui.visit.data.InteractionLog
+
+interface InteractionDetailsButtonClickListener {
+    fun onClick(interactionLog: InteractionLog)
+}

--- a/app/src/main/java/org/brightmindenrichment/street_care/ui/visit/visit_forms/InteractionLogRecyclerAdapter.kt
+++ b/app/src/main/java/org/brightmindenrichment/street_care/ui/visit/visit_forms/InteractionLogRecyclerAdapter.kt
@@ -1,0 +1,125 @@
+package org.brightmindenrichment.street_care.ui.visit.visit_forms
+
+import android.content.Context
+import android.graphics.drawable.GradientDrawable
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.RecyclerView
+import org.brightmindenrichment.street_care.R
+import org.brightmindenrichment.street_care.databinding.VisitLogListLayoutBinding
+import org.brightmindenrichment.street_care.ui.visit.InteractionLogDataAdapter
+import org.brightmindenrichment.street_care.ui.visit.data.InteractionLog
+import java.text.SimpleDateFormat
+import java.util.Locale
+import androidx.recyclerview.widget.LinearLayoutManager
+import org.brightmindenrichment.street_care.ui.visit.visit_forms.InteractionDetailsButtonClickListener
+import org.brightmindenrichment.street_care.ui.visit.visit_forms.InteractionLogRecyclerAdapter
+
+class InteractionLogRecyclerAdapter(
+    private val context: Context,
+    private val controller: InteractionLogDataAdapter,
+    private val clickListener: InteractionDetailsButtonClickListener
+) : RecyclerView.Adapter<InteractionLogRecyclerAdapter.ViewHolder>() {
+
+    private val dateTimeFormat = SimpleDateFormat("MMM d, yyyy | h:mma", Locale.getDefault())
+
+    inner class ViewHolder(
+        private val binding: VisitLogListLayoutBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: InteractionLog, position: Int, size: Int) {
+            binding.textViewDetails.text = item.formattedLocation().ifBlank { "Location" }
+
+            binding.textViewDate.text = item.startTimestamp
+                ?.toDate()
+                ?.let { dateTimeFormat.format(it) }
+                ?: "Date unavailable"
+
+            val status = item.displayStatus()
+
+            if (item.isPublic && status.isNotBlank()) {
+                binding.statusTextView.visibility = View.VISIBLE
+                binding.statusTextView.text = status
+
+                (binding.statusTextView.background as? GradientDrawable)?.setColor(
+                    ContextCompat.getColor(context, item.statusColor())
+                )
+            } else {
+                binding.statusTextView.visibility = View.GONE
+            }
+
+            binding.detailsButton.setOnClickListener {
+                Log.d("DETAILS_TEST", "InteractionLog details clicked")
+                clickListener.onClick(item)
+            }
+
+            when (position) {
+                0 -> {
+                    binding.timelineLine.visibility = View.GONE
+                    binding.timelineLineHalfUp.visibility = View.GONE
+                    binding.timelineLineHalfDown.visibility = View.VISIBLE
+                }
+
+                size - 1 -> {
+                    binding.timelineLine.visibility = View.GONE
+                    binding.timelineLineHalfUp.visibility = View.VISIBLE
+                    binding.timelineLineHalfDown.visibility = View.GONE
+                }
+
+                else -> {
+                    binding.timelineLine.visibility = View.VISIBLE
+                    binding.timelineLineHalfUp.visibility = View.GONE
+                    binding.timelineLineHalfDown.visibility = View.GONE
+                }
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = VisitLogListLayoutBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        controller.getInteractionAtPosition(position)?.let { interactionLog ->
+            holder.bind(interactionLog, position, itemCount)
+        }
+    }
+
+    override fun getItemCount(): Int {
+        return controller.size
+    }
+}
+
+private fun InteractionLog.formattedLocation(): String {
+    return listOf(addr1, addr2, city, state, zipcode)
+        .map { it.trim() }
+        .filter { it.isNotBlank() }
+        .joinToString(", ")
+}
+
+private fun InteractionLog.displayStatus(): String {
+    return when (status.trim().lowercase(Locale.US)) {
+        "approved", "published" -> "PUBLISHED"
+        "pending" -> "PENDING"
+        "rejected" -> "REJECTED"
+        else -> status.uppercase(Locale.US)
+    }
+}
+
+private fun InteractionLog.statusColor(): Int {
+    return when (status.trim().lowercase(Locale.US)) {
+        "approved", "published" -> R.color.status_green
+        "rejected" -> R.color.status_red
+        "pending" -> R.color.status_amber
+        else -> R.color.black
+    }
+}

--- a/app/src/main/res/drawable/bg_bottom_sheet_handle.xml
+++ b/app/src/main/res/drawable/bg_bottom_sheet_handle.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/gray300" />
+    <corners android:radius="4dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_interaction_bottom_sheet_white.xml
+++ b/app/src/main/res/drawable/bg_interaction_bottom_sheet_white.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/white" />
+    <corners
+        android:topLeftRadius="24dp"
+        android:topRightRadius="24dp"
+        android:bottomLeftRadius="0dp"
+        android:bottomRightRadius="0dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_interaction_chip.xml
+++ b/app/src/main/res/drawable/bg_interaction_chip.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/white" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/gray400" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_interaction_details_card_white.xml
+++ b/app/src/main/res/drawable/bg_interaction_details_card_white.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/white" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/gray300" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/layout/bottom_sheet_interaction_log_details.xml
+++ b/app/src/main/res/layout/bottom_sheet_interaction_log_details.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/interactionDetailsBottomSheet"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bg_interaction_bottom_sheet_white"
+    android:fillViewport="false"
+    android:paddingBottom="24dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="24dp"
+        android:paddingTop="10dp"
+        android:paddingEnd="24dp"
+        android:paddingBottom="24dp">
+
+        <View
+            android:layout_width="92dp"
+            android:layout_height="4dp"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginBottom="24dp"
+            android:background="@drawable/bg_bottom_sheet_handle" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_interaction_details_card_white"
+            android:orientation="vertical"
+            android:padding="20dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:src="@drawable/ic_person_icon"
+                    app:tint="@color/gray700" />
+
+                <TextView
+                    android:id="@+id/tvInteractionName"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="12dp"
+                    android:layout_weight="1"
+                    android:textColor="@color/black"
+                    android:textSize="20sp"
+                    android:textStyle="bold"
+                    tools:text="Boston" />
+
+                <ImageView
+                    android:id="@+id/ivInteractionVerified"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:src="@drawable/ic_verified_yellow" />
+            </LinearLayout>
+
+            <GridLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:columnCount="2">
+
+                <TextView
+                    android:id="@+id/tvInteractionDate"
+                    style="@style/InteractionSheetInfoText"
+                    android:drawableStart="@drawable/baseline_calendar_month_24"
+                    tools:text="04/13/2026" />
+
+                <TextView
+                    android:id="@+id/tvInteractionCityState"
+                    style="@style/InteractionSheetInfoText"
+                    android:drawableStart="@drawable/ic_baseline_location_on_24"
+                    tools:text="Boston, Massachusetts" />
+
+                <TextView
+                    android:id="@+id/tvInteractionPhone"
+                    style="@style/InteractionSheetInfoText"
+                    android:drawableStart="@drawable/ic_baseline_contact_phone_24"
+                    tools:text="N/A" />
+
+                <TextView
+                    android:id="@+id/tvInteractionTime"
+                    style="@style/InteractionSheetInfoText"
+                    android:drawableStart="@drawable/baseline_access_time_24"
+                    tools:text="06:00 PM - 08:00 PM" />
+
+                <TextView
+                    android:id="@+id/tvInteractionAddress"
+                    style="@style/InteractionSheetInfoText"
+                    android:drawableStart="@drawable/ic_location"
+                    tools:text="139 Tremont St, Boston, MA 02111, USA" />
+
+                <TextView
+                    android:id="@+id/tvInteractionEmail"
+                    style="@style/InteractionSheetInfoText"
+                    android:drawableStart="@drawable/ic_baseline_email_24"
+                    tools:text="bostonteam@example.org" />
+            </GridLayout>
+
+            <TextView
+                android:id="@+id/tvPeopleJoined"
+                style="@style/InteractionSheetMetricText"
+                android:layout_marginTop="20dp"
+                tools:text="People Joined                                      3" />
+
+            <TextView
+                android:id="@+id/tvHelpRequestCount"
+                style="@style/InteractionSheetMetricText"
+                tools:text="Help Request Count" />
+
+            <TextView
+                android:id="@+id/tvPeopleHelped"
+                style="@style/InteractionSheetMetricText"
+                tools:text="People Helped                                      2" />
+
+            <TextView
+                android:id="@+id/tvCarePackagesDistributed"
+                style="@style/InteractionSheetMetricText"
+                tools:text="Care Packages Distributed                 1" />
+
+            <com.google.android.flexbox.FlexboxLayout
+                android:id="@+id/supportChipContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                app:flexWrap="wrap">
+
+                <TextView
+                    style="@style/InteractionSheetChip"
+                    tools:text="Food and Drink" />
+
+                <TextView
+                    style="@style/InteractionSheetChip"
+                    tools:text="Hygiene Products" />
+
+                <TextView
+                    style="@style/InteractionSheetChip"
+                    tools:text="Wellness / Emotional Support" />
+            </com.google.android.flexbox.FlexboxLayout>
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/btnCloseInteractionDetails"
+            android:layout_width="match_parent"
+            android:layout_height="44dp"
+            android:layout_marginTop="20dp"
+            android:background="@drawable/round_outlined_button"
+            android:gravity="center"
+            android:text="@string/close"
+            android:textColor="@color/dark_green"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -774,4 +774,10 @@ If needed, you may fill out  one log \n for your entire day.
     <string name="increase">Increase</string>
     <string name="decrease">Decrease</string>
 
+
+    <string name="people_joined_count">People Joined %1$d</string>
+    <string name="help_request_count_value">Help Request Count %1$d</string>
+    <string name="people_helped_count">People Helped %1$d</string>
+    <string name="care_packages_distributed_count">Care Packages Distributed %1$d</string>
+
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -129,4 +129,38 @@
         <item name="android:fontFamily">@font/poppins_bold_new</item>
     </style>
 
+    <style name="InteractionSheetInfoText">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_columnWeight">1</item>
+        <item name="android:layout_marginBottom">14dp</item>
+        <item name="android:drawablePadding">8dp</item>
+        <item name="android:textColor">@color/gray700</item>
+        <item name="android:textSize">14sp</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="InteractionSheetMetricText">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_marginBottom">16dp</item>
+        <item name="android:textColor">@color/black</item>
+        <item name="android:textSize">15sp</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="InteractionSheetChip">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_marginEnd">8dp</item>
+        <item name="android:layout_marginBottom">8dp</item>
+        <item name="android:background">@drawable/bg_interaction_chip</item>
+        <item name="android:paddingStart">14dp</item>
+        <item name="android:paddingTop">6dp</item>
+        <item name="android:paddingEnd">14dp</item>
+        <item name="android:paddingBottom">6dp</item>
+        <item name="android:textColor">@color/gray700</item>
+        <item name="android:textSize">13sp</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
## Summary
- Added a bottom sheet layout for interaction log details.
- Wired interaction log history items to open the new details bottom sheet.
- Populated the bottom sheet with selected interaction log data from Firestore-backed models instead of hardcoded values.
- Added supporting styles, drawables, and string resources for the new UI.

## Testing
- Built the app successfully with Gradle.
- Verified the Interaction Log screen loads with the updated adapter.
- Verified the Details action opens the new bottom sheet instead of navigating to the old details fragment.

<img width="742" height="937" alt="image" src="https://github.com/user-attachments/assets/566613a2-20cf-40e5-933a-5d61c79e6e87" />
<img width="568" height="906" alt="image" src="https://github.com/user-attachments/assets/77cdce61-1b6c-4bdb-a24b-d57e85bb7087" />
